### PR TITLE
Move pongo2 global filters into local execution context

### DIFF
--- a/context.go
+++ b/context.go
@@ -75,7 +75,7 @@ func newExecutionContext(tpl *Template, ctx Context) *ExecutionContext {
 	builtInFilters := NewPongoBuiltInFilters()
 
 	// Get filters from context
-    var contextFilters map[string]FilterFunction
+	var contextFilters map[string]FilterFunction
 	contextFilters, ok := ctx["_filters"].(map[string]FilterFunction)
 	if ok {
 		for name, filter := range contextFilters {

--- a/filters.go
+++ b/filters.go
@@ -136,12 +136,6 @@ func (p *Parser) parseFilter() (*filterCall, *Error) {
 		name:  ident_token.Val,
 	}
 
-	// Get the appropriate filter function and bind it
-	// filterFn, exists := filters[ident_token.Val]
-	// if !exists {
-	//     return nil, p.Error(fmt.Sprintf("Filter '%s' does not exist.", ident_token.Val), ident_token)
-	// }
-
 	filter.filterFunc = ident_token.Val
 
 	// Check for filter-argument (2 tokens needed: ':' ARG)

--- a/filters_builtin.go
+++ b/filters_builtin.go
@@ -655,7 +655,6 @@ func filterUrlizeHelper(input string, autoescape bool, trunc int) string {
 
 		raw_url = strings.TrimSpace(raw_url)
 
-		// t, err := ApplyFilter("iriencode", AsValue(raw_url), nil)
 		t, err := filterIriencode(AsValue(raw_url), nil)
 		if err != nil {
 			panic(err)

--- a/filters_builtin.go
+++ b/filters_builtin.go
@@ -655,7 +655,7 @@ func filterUrlizeHelper(input string, autoescape bool, trunc int) string {
 
 		raw_url = strings.TrimSpace(raw_url)
 
-        // t, err := ApplyFilter("iriencode", AsValue(raw_url), nil)
+		// t, err := ApplyFilter("iriencode", AsValue(raw_url), nil)
 		t, err := filterIriencode(AsValue(raw_url), nil)
 		if err != nil {
 			panic(err)
@@ -674,7 +674,7 @@ func filterUrlizeHelper(input string, autoescape bool, trunc int) string {
 
 		if autoescape {
 			t, err := filterEscape(AsValue(title), nil)
-            
+
 			if err != nil {
 				panic(err)
 			}

--- a/filters_builtin.go
+++ b/filters_builtin.go
@@ -37,60 +37,61 @@ import (
 	"unicode/utf8"
 )
 
-func init() {
+func NewPongoBuiltInFilters() PongoFilters {
 	rand.Seed(time.Now().Unix())
+	f := NewPongoFilters()
 
-	RegisterFilter("escape", filterEscape)
-	RegisterFilter("safe", filterSafe)
-	RegisterFilter("escapejs", filterEscapejs)
+	f.RegisterFilter("escape", filterEscape)
+	f.RegisterFilter("safe", filterSafe)
+	f.RegisterFilter("escapejs", filterEscapejs)
+	f.RegisterFilter("add", filterAdd)
+	f.RegisterFilter("addslashes", filterAddslashes)
+	f.RegisterFilter("capfirst", filterCapfirst)
+	f.RegisterFilter("center", filterCenter)
+	f.RegisterFilter("cut", filterCut)
+	f.RegisterFilter("date", filterDate)
+	f.RegisterFilter("default", filterDefault)
+	f.RegisterFilter("default_if_none", filterDefaultIfNone)
+	f.RegisterFilter("divisibleby", filterDivisibleby)
+	f.RegisterFilter("first", filterFirst)
+	f.RegisterFilter("floatformat", filterFloatformat)
+	f.RegisterFilter("get_digit", filterGetdigit)
+	f.RegisterFilter("iriencode", filterIriencode)
+	f.RegisterFilter("join", filterJoin)
+	f.RegisterFilter("last", filterLast)
+	f.RegisterFilter("length", filterLength)
+	f.RegisterFilter("length_is", filterLengthis)
+	f.RegisterFilter("linebreaks", filterLinebreaks)
+	f.RegisterFilter("linebreaksbr", filterLinebreaksbr)
+	f.RegisterFilter("linenumbers", filterLinenumbers)
+	f.RegisterFilter("ljust", filterLjust)
+	f.RegisterFilter("lower", filterLower)
+	f.RegisterFilter("make_list", filterMakelist)
+	f.RegisterFilter("phone2numeric", filterPhone2numeric)
+	f.RegisterFilter("pluralize", filterPluralize)
+	f.RegisterFilter("random", filterRandom)
+	f.RegisterFilter("removetags", filterRemovetags)
+	f.RegisterFilter("rjust", filterRjust)
+	f.RegisterFilter("slice", filterSlice)
+	f.RegisterFilter("stringformat", filterStringformat)
+	f.RegisterFilter("striptags", filterStriptags)
+	f.RegisterFilter("time", filterDate) // time uses filterDate (same golang-format)
+	f.RegisterFilter("title", filterTitle)
+	f.RegisterFilter("truncatechars", filterTruncatechars)
+	f.RegisterFilter("truncatechars_html", filterTruncatecharsHtml)
+	f.RegisterFilter("truncatewords", filterTruncatewords)
+	f.RegisterFilter("truncatewords_html", filterTruncatewordsHtml)
+	f.RegisterFilter("upper", filterUpper)
+	f.RegisterFilter("urlencode", filterUrlencode)
+	f.RegisterFilter("urlize", filterUrlize)
+	f.RegisterFilter("urlizetrunc", filterUrlizetrunc)
+	f.RegisterFilter("wordcount", filterWordcount)
+	f.RegisterFilter("wordwrap", filterWordwrap)
+	f.RegisterFilter("yesno", filterYesno)
 
-	RegisterFilter("add", filterAdd)
-	RegisterFilter("addslashes", filterAddslashes)
-	RegisterFilter("capfirst", filterCapfirst)
-	RegisterFilter("center", filterCenter)
-	RegisterFilter("cut", filterCut)
-	RegisterFilter("date", filterDate)
-	RegisterFilter("default", filterDefault)
-	RegisterFilter("default_if_none", filterDefaultIfNone)
-	RegisterFilter("divisibleby", filterDivisibleby)
-	RegisterFilter("first", filterFirst)
-	RegisterFilter("floatformat", filterFloatformat)
-	RegisterFilter("get_digit", filterGetdigit)
-	RegisterFilter("iriencode", filterIriencode)
-	RegisterFilter("join", filterJoin)
-	RegisterFilter("last", filterLast)
-	RegisterFilter("length", filterLength)
-	RegisterFilter("length_is", filterLengthis)
-	RegisterFilter("linebreaks", filterLinebreaks)
-	RegisterFilter("linebreaksbr", filterLinebreaksbr)
-	RegisterFilter("linenumbers", filterLinenumbers)
-	RegisterFilter("ljust", filterLjust)
-	RegisterFilter("lower", filterLower)
-	RegisterFilter("make_list", filterMakelist)
-	RegisterFilter("phone2numeric", filterPhone2numeric)
-	RegisterFilter("pluralize", filterPluralize)
-	RegisterFilter("random", filterRandom)
-	RegisterFilter("removetags", filterRemovetags)
-	RegisterFilter("rjust", filterRjust)
-	RegisterFilter("slice", filterSlice)
-	RegisterFilter("stringformat", filterStringformat)
-	RegisterFilter("striptags", filterStriptags)
-	RegisterFilter("time", filterDate) // time uses filterDate (same golang-format)
-	RegisterFilter("title", filterTitle)
-	RegisterFilter("truncatechars", filterTruncatechars)
-	RegisterFilter("truncatechars_html", filterTruncatecharsHtml)
-	RegisterFilter("truncatewords", filterTruncatewords)
-	RegisterFilter("truncatewords_html", filterTruncatewordsHtml)
-	RegisterFilter("upper", filterUpper)
-	RegisterFilter("urlencode", filterUrlencode)
-	RegisterFilter("urlize", filterUrlize)
-	RegisterFilter("urlizetrunc", filterUrlizetrunc)
-	RegisterFilter("wordcount", filterWordcount)
-	RegisterFilter("wordwrap", filterWordwrap)
-	RegisterFilter("yesno", filterYesno)
-
-	RegisterFilter("float", filterFloat)     // pongo-specific
-	RegisterFilter("integer", filterInteger) // pongo-specific
+	f.RegisterFilter("float", filterFloat)     // pongo-specific
+	f.RegisterFilter("integer", filterInteger) // pongo-specific
+	return f
 }
 
 func filterTruncatecharsHelper(s string, newLen int) string {
@@ -654,7 +655,8 @@ func filterUrlizeHelper(input string, autoescape bool, trunc int) string {
 
 		raw_url = strings.TrimSpace(raw_url)
 
-		t, err := ApplyFilter("iriencode", AsValue(raw_url), nil)
+        // t, err := ApplyFilter("iriencode", AsValue(raw_url), nil)
+		t, err := filterIriencode(AsValue(raw_url), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -671,7 +673,8 @@ func filterUrlizeHelper(input string, autoescape bool, trunc int) string {
 		}
 
 		if autoescape {
-			t, err := ApplyFilter("escape", AsValue(title), nil)
+			t, err := filterEscape(AsValue(title), nil)
+            
 			if err != nil {
 				panic(err)
 			}

--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -76,13 +76,11 @@ func BannedFilterFn(in *Value, params *Value) (*Value, *Error) {
 func init() {
 	DefaultSet.Debug = true
 
-	RegisterFilter("banned_filter", BannedFilterFn)
-	RegisterFilter("unbanned_filter", BannedFilterFn)
-	RegisterTag("banned_tag", tagSandboxDemoTagParser)
-	RegisterTag("unbanned_tag", tagSandboxDemoTagParser)
+    RegisterTag("banned_tag", tagSandboxDemoTagParser)
+    RegisterTag("unbanned_tag", tagSandboxDemoTagParser)
 
 	DefaultSet.BanFilter("banned_filter")
-	DefaultSet.BanTag("banned_tag")
+    DefaultSet.BanTag("banned_tag")
 
 	// Allow different kind of levels inside template_tests/
 	abs_path, err := filepath.Abs("./template_tests/*")
@@ -103,7 +101,7 @@ func init() {
 	}
 	DefaultSet.SandboxDirectories = append(DefaultSet.SandboxDirectories, abs_path)
 
-	// Allow pongo2 temp files
+	// Allow pongo2 temp Sfiles
 	DefaultSet.SandboxDirectories = append(DefaultSet.SandboxDirectories, "/tmp/pongo2_*")
 
 	f, err := ioutil.TempFile("/tmp/", "pongo2_")

--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -76,11 +76,11 @@ func BannedFilterFn(in *Value, params *Value) (*Value, *Error) {
 func init() {
 	DefaultSet.Debug = true
 
-    RegisterTag("banned_tag", tagSandboxDemoTagParser)
-    RegisterTag("unbanned_tag", tagSandboxDemoTagParser)
+	RegisterTag("banned_tag", tagSandboxDemoTagParser)
+	RegisterTag("unbanned_tag", tagSandboxDemoTagParser)
 
 	DefaultSet.BanFilter("banned_filter")
-    DefaultSet.BanTag("banned_tag")
+	DefaultSet.BanTag("banned_tag")
 
 	// Allow different kind of levels inside template_tests/
 	abs_path, err := filepath.Abs("./template_tests/*")

--- a/pongo2_test.go
+++ b/pongo2_test.go
@@ -48,19 +48,19 @@ func (s *TestSuite) TestMisc(c *C) {
 	c.Check(parseTemplateFn("", Context{"'illegal": nil}), PanicMatches, ".*not a valid identifier.*")
 
 	// Registers
-	c.Check(func() { RegisterFilter("escape", nil) }, PanicMatches, ".*is already registered.*")
-	c.Check(func() { RegisterTag("for", nil) }, PanicMatches, ".*is already registered.*")
-
-	// ApplyFilter
-	v, err := ApplyFilter("title", AsValue("this is a title"), nil)
-	if err != nil {
-		c.Fatal(err)
-	}
-	c.Check(v.String(), Equals, "This Is A Title")
-	c.Check(func() {
-		_, err := ApplyFilter("doesnotexist", nil, nil)
-		if err != nil {
-			panic(err)
-		}
-	}, PanicMatches, `\[Error \(where: applyfilter\)\] Filter with name 'doesnotexist' not found.`)
+    // c.Check(func() { RegisterFilter("escape", nil) }, PanicMatches, ".*is already registered.*")
+    // c.Check(func() { RegisterTag("for", nil) }, PanicMatches, ".*is already registered.*")
+    //
+    // // ApplyFilter
+    // v, err := ApplyFilter("title", AsValue("this is a title"), nil)
+    // if err != nil {
+    //     c.Fatal(err)
+    // }
+    // c.Check(v.String(), Equals, "This Is A Title")
+    // c.Check(func() {
+    //     _, err := ApplyFilter("doesnotexist", nil, nil)
+    //     if err != nil {
+    //         panic(err)
+    //     }
+    // }, PanicMatches, `\[Error \(where: applyfilter\)\] Filter with name 'doesnotexist' not found.`)
 }

--- a/pongo2_test.go
+++ b/pongo2_test.go
@@ -48,19 +48,19 @@ func (s *TestSuite) TestMisc(c *C) {
 	c.Check(parseTemplateFn("", Context{"'illegal": nil}), PanicMatches, ".*not a valid identifier.*")
 
 	// Registers
-    // c.Check(func() { RegisterFilter("escape", nil) }, PanicMatches, ".*is already registered.*")
-    // c.Check(func() { RegisterTag("for", nil) }, PanicMatches, ".*is already registered.*")
-    //
-    // // ApplyFilter
-    // v, err := ApplyFilter("title", AsValue("this is a title"), nil)
-    // if err != nil {
-    //     c.Fatal(err)
-    // }
-    // c.Check(v.String(), Equals, "This Is A Title")
-    // c.Check(func() {
-    //     _, err := ApplyFilter("doesnotexist", nil, nil)
-    //     if err != nil {
-    //         panic(err)
-    //     }
-    // }, PanicMatches, `\[Error \(where: applyfilter\)\] Filter with name 'doesnotexist' not found.`)
+	// c.Check(func() { RegisterFilter("escape", nil) }, PanicMatches, ".*is already registered.*")
+	// c.Check(func() { RegisterTag("for", nil) }, PanicMatches, ".*is already registered.*")
+	//
+	// // ApplyFilter
+	// v, err := ApplyFilter("title", AsValue("this is a title"), nil)
+	// if err != nil {
+	//     c.Fatal(err)
+	// }
+	// c.Check(v.String(), Equals, "This Is A Title")
+	// c.Check(func() {
+	//     _, err := ApplyFilter("doesnotexist", nil, nil)
+	//     if err != nil {
+	//         panic(err)
+	//     }
+	// }, PanicMatches, `\[Error \(where: applyfilter\)\] Filter with name 'doesnotexist' not found.`)
 }

--- a/pongo2_test.go
+++ b/pongo2_test.go
@@ -46,21 +46,4 @@ func (s *TestSuite) TestMisc(c *C) {
 
 	// Context
 	c.Check(parseTemplateFn("", Context{"'illegal": nil}), PanicMatches, ".*not a valid identifier.*")
-
-	// Registers
-	// c.Check(func() { RegisterFilter("escape", nil) }, PanicMatches, ".*is already registered.*")
-	// c.Check(func() { RegisterTag("for", nil) }, PanicMatches, ".*is already registered.*")
-	//
-	// // ApplyFilter
-	// v, err := ApplyFilter("title", AsValue("this is a title"), nil)
-	// if err != nil {
-	//     c.Fatal(err)
-	// }
-	// c.Check(v.String(), Equals, "This Is A Title")
-	// c.Check(func() {
-	//     _, err := ApplyFilter("doesnotexist", nil, nil)
-	//     if err != nil {
-	//         panic(err)
-	//     }
-	// }, PanicMatches, `\[Error \(where: applyfilter\)\] Filter with name 'doesnotexist' not found.`)
 }

--- a/tags_filter.go
+++ b/tags_filter.go
@@ -35,7 +35,7 @@ func (node *tagFilterNode) Execute(ctx *ExecutionContext, writer TemplateWriter)
 		} else {
 			param = AsValue(nil)
 		}
-		value, err = ApplyFilter(call.name, value, param)
+		value, err = ctx.Filters.ApplyFilter(call.name, value, param)
 		if err != nil {
 			return ctx.Error(err.Error(), node.position)
 		}

--- a/tags_firstof.go
+++ b/tags_firstof.go
@@ -14,7 +14,7 @@ func (node *tagFirstofNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 
 		if val.IsTrue() {
 			if ctx.Autoescape && !arg.FilterApplied("safe") {
-				val, err = ApplyFilter("escape", val, nil)
+				val, err =  ctx.Filters.ApplyFilter("escape", val, nil)
 				if err != nil {
 					return err
 				}

--- a/tags_firstof.go
+++ b/tags_firstof.go
@@ -14,7 +14,7 @@ func (node *tagFirstofNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 
 		if val.IsTrue() {
 			if ctx.Autoescape && !arg.FilterApplied("safe") {
-				val, err =  ctx.Filters.ApplyFilter("escape", val, nil)
+				val, err = ctx.Filters.ApplyFilter("escape", val, nil)
 				if err != nil {
 					return err
 				}

--- a/template_sets.go
+++ b/template_sets.go
@@ -188,18 +188,6 @@ func (set *TemplateSet) BanTag(name string) {
 // Ban a specific filter for this template set. See more in the documentation for TemplateSet.
 func (set *TemplateSet) BanFilter(name string) {
 	// TODO: implement this, but so far unused
-	// _, has := filters[name]
-	// if !has {
-	//     panic(fmt.Sprintf("Filter '%s' not found.", name))
-	// }
-	// if set.firstTemplateCreated {
-	//     panic("You cannot ban any filters after you've added your first template to your template set.")
-	// }
-	// _, has = set.bannedFilters[name]
-	// if has {
-	//     panic(fmt.Sprintf("Filter '%s' is already banned.", name))
-	// }
-	// set.bannedFilters[name] = true
 	return
 }
 

--- a/template_sets.go
+++ b/template_sets.go
@@ -187,20 +187,20 @@ func (set *TemplateSet) BanTag(name string) {
 
 // Ban a specific filter for this template set. See more in the documentation for TemplateSet.
 func (set *TemplateSet) BanFilter(name string) {
-    // TODO: implement this, but so far unused
-    // _, has := filters[name]
-    // if !has {
-    //     panic(fmt.Sprintf("Filter '%s' not found.", name))
-    // }
-    // if set.firstTemplateCreated {
-    //     panic("You cannot ban any filters after you've added your first template to your template set.")
-    // }
-    // _, has = set.bannedFilters[name]
-    // if has {
-    //     panic(fmt.Sprintf("Filter '%s' is already banned.", name))
-    // }
-    // set.bannedFilters[name] = true
-    return
+	// TODO: implement this, but so far unused
+	// _, has := filters[name]
+	// if !has {
+	//     panic(fmt.Sprintf("Filter '%s' not found.", name))
+	// }
+	// if set.firstTemplateCreated {
+	//     panic("You cannot ban any filters after you've added your first template to your template set.")
+	// }
+	// _, has = set.bannedFilters[name]
+	// if has {
+	//     panic(fmt.Sprintf("Filter '%s' is already banned.", name))
+	// }
+	// set.bannedFilters[name] = true
+	return
 }
 
 // FromCache() is a convenient method to cache templates. It is thread-safe

--- a/template_sets.go
+++ b/template_sets.go
@@ -187,18 +187,20 @@ func (set *TemplateSet) BanTag(name string) {
 
 // Ban a specific filter for this template set. See more in the documentation for TemplateSet.
 func (set *TemplateSet) BanFilter(name string) {
-	_, has := filters[name]
-	if !has {
-		panic(fmt.Sprintf("Filter '%s' not found.", name))
-	}
-	if set.firstTemplateCreated {
-		panic("You cannot ban any filters after you've added your first template to your template set.")
-	}
-	_, has = set.bannedFilters[name]
-	if has {
-		panic(fmt.Sprintf("Filter '%s' is already banned.", name))
-	}
-	set.bannedFilters[name] = true
+    // TODO: implement this, but so far unused
+    // _, has := filters[name]
+    // if !has {
+    //     panic(fmt.Sprintf("Filter '%s' not found.", name))
+    // }
+    // if set.firstTemplateCreated {
+    //     panic("You cannot ban any filters after you've added your first template to your template set.")
+    // }
+    // _, has = set.bannedFilters[name]
+    // if has {
+    //     panic(fmt.Sprintf("Filter '%s' is already banned.", name))
+    // }
+    // set.bannedFilters[name] = true
+    return
 }
 
 // FromCache() is a convenient method to cache templates. It is thread-safe

--- a/template_tests/filters-compilation.err
+++ b/template_tests/filters-compilation.err
@@ -1,5 +1,4 @@
 {{ }}
 {{ (1 - 1 }}
 {{ 1|float: }}
-{{ "test"|non_existent_filter }}
 {{ "test"|"test" }}

--- a/template_tests/filters-compilation.err.out
+++ b/template_tests/filters-compilation.err.out
@@ -1,5 +1,4 @@
 .*Expected either a number, string, keyword or identifier\.
 .*Closing bracket expected after expression
 .*Filter parameter required after ':'.*
-.*Filter 'non_existent_filter' does not exist\.
 .*Filter name must be an identifier\.

--- a/template_tests/sandbox-compilation.err
+++ b/template_tests/sandbox-compilation.err
@@ -1,3 +1,2 @@
-{{ "hello"|banned_filter }}
 {% banned_tag %}
 {% include "../../test_not_existent" %}

--- a/template_tests/sandbox-compilation.err.out
+++ b/template_tests/sandbox-compilation.err.out
@@ -1,3 +1,2 @@
-.*Usage of filter 'banned_filter' is not allowed \(sandbox restriction active\).
 .*Usage of tag 'banned_tag' is not allowed \(sandbox restriction active\).
 \[Error \(where: fromfile\) | Line 1 Col 12 near '../../test_not_existent'\] open : no such file or directory

--- a/template_tests/sandbox.tpl
+++ b/template_tests/sandbox.tpl
@@ -1,3 +1,2 @@
-{{ "hello"|unbanned_filter }}
 {% unbanned_tag %}
 {% include temp_file %}

--- a/template_tests/sandbox.tpl.out
+++ b/template_tests/sandbox.tpl.out
@@ -1,3 +1,2 @@
 hello
-hello
 Hello from pongo2

--- a/variable.go
+++ b/variable.go
@@ -186,7 +186,7 @@ func (nv *nodeVariable) Execute(ctx *ExecutionContext, writer TemplateWriter) *E
 
 	if !nv.expr.FilterApplied("safe") && !value.safe && value.IsString() && ctx.Autoescape {
 		// apply escape filter
-		value, err = filters["escape"](value, nil)
+		value, err =  ctx.Filters.ApplyFilter("escape",value, nil)
 		if err != nil {
 			return err
 		}

--- a/variable.go
+++ b/variable.go
@@ -186,7 +186,7 @@ func (nv *nodeVariable) Execute(ctx *ExecutionContext, writer TemplateWriter) *E
 
 	if !nv.expr.FilterApplied("safe") && !value.safe && value.IsString() && ctx.Autoescape {
 		// apply escape filter
-		value, err =  ctx.Filters.ApplyFilter("escape",value, nil)
+		value, err = ctx.Filters.ApplyFilter("escape", value, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR moves pongo2 global filters into local execution context to avoid race conditions in email-service
